### PR TITLE
directly return the output where possible

### DIFF
--- a/lib/optimiser.js
+++ b/lib/optimiser.js
@@ -16,6 +16,7 @@ exports.optimise = function (ast) {
   ast = removeUnusedVariableDeclarators(ast);
   ast = combineContiguousOutputStatements(ast);
   ast = normalizeFirstOutputStatement(ast);
+  ast = directReturnWherePossible(ast);
   return ast;
 };
 
@@ -305,7 +306,10 @@ function replaceContextReferences (ast) {
       this.skip();
       traverse.traverse(node, {
         enter: function (item, parent) {
-          if (item !== node && (item.type === 'FunctionExpression' || item.type === 'FunctionDeclaration')) {
+          if (
+            item !== node &&
+            (item.type === 'FunctionExpression' || item.type === 'FunctionDeclaration')
+          ) {
             this.skip();
           }
           else if (
@@ -317,6 +321,82 @@ function replaceContextReferences (ast) {
           }
         }
       });
+    }
+    else if (node.type === 'FunctionDeclaration') {
+      this.skip();
+    }
+  }});
+  return ast;
+}
+
+function directReturnWherePossible (ast) {
+  traverse.traverse(ast, { enter: function (node) {
+    if (node.type === 'FunctionExpression') {
+      var canOptimise = true,
+          declaration, declarator, assignment, returnStatement;
+      this.skip();
+      traverse.traverse(node, {
+        enter: function (item, parent) {
+          if (
+            item !== node &&
+            (item.type === 'FunctionExpression' || item.type === 'FunctionDeclaration')
+          ) {
+            canOptimise = false;
+            this.break();
+          }
+          else if (
+            item.type === 'IfStatement' ||
+            item.type === 'ForStatement'
+          ) {
+            canOptimise = false;
+            this.break();
+          }
+          else if (item.type === 'VariableDeclarator' && item.id.name === 'html') {
+            declarator = item;
+            this.skip();
+          }
+          else if (item.type === 'VariableDeclaration') {
+            if (declaration) {
+              canOptimise = false;
+              this.skip();
+            }
+            else {
+              declaration = item;
+            }
+          }
+          else if (item.type === 'AssignmentExpression' && item.left.name === 'html') {
+            if (assignment) {
+              canOptimise = false;
+              this.break();
+            }
+            else {
+              assignment = item;
+              this.skip();
+            }
+          }
+          else if (item.type === 'ReturnStatement') {
+            returnStatement = item;
+            this.skip();
+          }
+        }
+      });
+      if (canOptimise) {
+        declaration.declarations = fast.filter(declaration.declarations, function (item) {
+          return item !== declarator;
+        });
+        returnStatement.argument = assignment.right;
+        node.body.body = fast.filter(node.body.body, function (item) {
+          if (item === declaration && !declaration.declarations.length) {
+            return false;
+          }
+          else if (item.type === 'ExpressionStatement' && item.expression === assignment) {
+            return false;
+          }
+          else {
+            return true;
+          }
+        });
+      }
     }
     else if (node.type === 'FunctionDeclaration') {
       this.skip();


### PR DESCRIPTION
Turns:

``` js
var html;
html = '<p>Hello World</p>';
return html;
```

into

``` js
return '<p>Hello World</p>';
```
